### PR TITLE
Small changes for running on EC clusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,15 @@
-#CXX:=g++
-#CC:=gcc
+# Comment these out to use clang
+CXX:=g++
+CC:=gcc
 
 #
 # clang 3.0 should work.
 # clang 2.9 is known to be broken, as it can't seem to
 #	compile the GNU header files…
 #
-CXX:=clang++
-CC:=clang
+# Uncomment these to use clang
+#CXX:=clang++
+#CC:=clang
 
 AR:=ar
 

--- a/search/lsslrtastar.hpp
+++ b/search/lsslrtastar.hpp
@@ -8,6 +8,7 @@
 #include <ctime>
 #include <cerrno>
 #include <vector>
+#include <algorithm>
 
 class LookaheadLimit {
 public:


### PR DESCRIPTION
Two changes:
1. Edit the Makefile to use GCC by default instead of Clang
2. Add the `#include <algorithm>` line to **lsslrtastar.hpp**.